### PR TITLE
Replace two checks with one, since they're all mutually exclusive.

### DIFF
--- a/src/bin/cindex.rs
+++ b/src/bin/cindex.rs
@@ -44,8 +44,7 @@ fn is_regular_file(meta: FileType) -> bool {
 
 #[cfg(unix)]
 fn is_regular_file(meta: FileType) -> bool {
-    !meta.is_dir()
-        && !meta.is_symlink()
+    meta.is_file()
         && !meta.is_fifo()
         && !meta.is_socket()
         && !meta.is_block_device()


### PR DESCRIPTION
According the rust [docs](https://doc.rust-lang.org/stable/std/fs/struct.FileType.html#method.is_file), the `is_file()`, `is_dir()` and `is_symlink()` methods should all be mutually exclusive, so only one of them should pass. So let's replace two checks with just one.